### PR TITLE
UUIDをデフォルトとする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,10 @@ module MyRails8Template
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # UUIDをデフォルトとする
+    config.generators do |g|
+      g.orm :active_record, primary_key_type: :uuid
+    end
   end
 end


### PR DESCRIPTION
# やったこと

`rails g model Hoge`等で自動生成されるmigrationファイルの主キーのデフォルトをuuidにした