### PR TITLE
UUID設定をコメントアウト

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,8 +40,10 @@ module MyRails8Template
     config.generators.system_tests = nil
 
     # UUIDをデフォルトとする
-    config.generators do |g|
-      g.orm :active_record, primary_key_type: :uuid
-    end
+    # SQLiteでは利用不可能
+    #
+    # config.generators do |g|
+    #   g.orm :active_record, primary_key_type: :uuid
+    # end
   end
 end


### PR DESCRIPTION
## やったこと

SQLiteではUUIDは使えなさそうなのでgeneratorの設定をコメントアウトする